### PR TITLE
feat: add dark mode support

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,12 +25,19 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
-        <Toaster />
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {children}
+          <Toaster />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { Search } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { PromptCard } from '@/components/PromptCard';
+import { ThemeToggle } from '@/components/theme-toggle';
 import { usePromptSearch } from '@/hooks/usePromptSearch';
 import { STUB_PROMPTS } from '@/data/prompts';
 
@@ -12,7 +13,10 @@ export default function HomePage() {
   return (
     <div className="container mx-auto py-8 px-4 max-w-4xl">
       <header className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Prompt Library</h1>
+        <div className="flex items-start justify-between gap-4 mb-2">
+          <h1 className="text-3xl font-bold">Prompt Library</h1>
+          <ThemeToggle />
+        </div>
         <p className="text-muted-foreground">
           Search and copy prompt templates for your AI workflows
         </p>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import * as React from 'react';
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import * as React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { Button } from '@/components/ui/button';
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return <Button variant="outline" size="icon" disabled />;
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+    >
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
Implements dark mode support for the application using next-themes.

### Changes
- Created ThemeProvider component wrapping next-themes
- Added ThemeToggle component with sun/moon icons
- Integrated ThemeProvider in root layout with system theme detection
- Added theme toggle button to page header
- Utilized existing dark mode CSS variables from globals.css

Closes #12

Generated with [Claude Code](https://claude.ai/code)